### PR TITLE
Add wrapper for DbCommand, DbConnection and DbTransaction to support EF

### DIFF
--- a/src/DataDog.Tracing.Sql.Tests/EntityFrameworkCore/TraceDbCommandTests.cs
+++ b/src/DataDog.Tracing.Sql.Tests/EntityFrameworkCore/TraceDbCommandTests.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using NUnit.Framework;
+
+namespace DataDog.Tracing.Sql.Tests.EntityFrameworkCore
+{
+    [TestFixture]
+    public class TraceDbCommandTests
+    {
+        RootSpan _root;
+        SqliteConnection _conn;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _conn = new SqliteConnection("Filename=./test.db");
+            _conn.Open();
+            _root = new RootSpan();
+        }
+
+        [Test]
+        [TestCase(CommandBehavior.Default)]
+        [TestCase(CommandBehavior.CloseConnection)]
+        public void ExecuteReader_is_traced(CommandBehavior commandBehavior)
+        {
+            var customers = new List<Customer>();
+            using (var command = new Sql.EntityFrameworkCore.TraceDbCommand(_conn.CreateCommand(), _root))
+            {
+                command.CommandText = "SELECT * FROM Customers";
+                command.CommandType = CommandType.Text;
+                using (var reader = command.ExecuteReader(commandBehavior))
+                {
+                    while (reader.Read())
+                    {
+                        customers.Add(new Customer(reader));
+                    }
+                }
+            }
+            customers.Count.Should().Be(2);
+            _root.Spans[1].Name.Should().Be("sql." + nameof(IDbCommand.ExecuteReader));
+            _root.Spans[1].Service.Should().Be("sql");
+            _root.Spans[1].Resource.Should().Be("main");
+            _root.Spans[1].Type.Should().Be("sql");
+            _root.Spans[1].Error.Should().Be(0);
+            _root.Spans[1].Meta["sql.CommandBehavior"].Should().Be(commandBehavior.ToString("x"));
+            _root.Spans[1].Meta["sql.CommandText"].Should().Be("SELECT * FROM Customers");
+            _root.Spans[1].Meta["sql.CommandType"].Should().Be("Text");
+        }
+
+        [Test]
+        public void ExecuteNonQuery_is_traced()
+        {
+            int rows;
+            using (var command = new Sql.EntityFrameworkCore.TraceDbCommand(_conn.CreateCommand(), _root))
+            {
+                command.CommandText = "SELECT * FROM Customers";
+                command.CommandType = CommandType.Text;
+                rows = command.ExecuteNonQuery();
+            }
+            _root.Spans[1].Name.Should().Be("sql." + nameof(IDbCommand.ExecuteNonQuery));
+            _root.Spans[1].Service.Should().Be("sql");
+            _root.Spans[1].Resource.Should().Be("main");
+            _root.Spans[1].Type.Should().Be("sql");
+            _root.Spans[1].Error.Should().Be(0);
+            _root.Spans[1].Meta["sql.RowsAffected"].Should().Be(rows.ToString());
+            _root.Spans[1].Meta["sql.CommandText"].Should().Be("SELECT * FROM Customers");
+            _root.Spans[1].Meta["sql.CommandType"].Should().Be("Text");
+        }
+
+        [Test]
+        public void ExecuteScalar_is_traced()
+        {
+            object result;
+            using (var command = new Sql.EntityFrameworkCore.TraceDbCommand(_conn.CreateCommand(), _root))
+            {
+                command.CommandText = "SELECT COUNT(*) FROM Customers";
+                command.CommandType = CommandType.Text;
+                result = command.ExecuteScalar();
+            }
+            result.Should().Be(2L);
+            _root.Spans[1].Name.Should().Be("sql." + nameof(IDbCommand.ExecuteScalar));
+            _root.Spans[1].Service.Should().Be("sql");
+            _root.Spans[1].Resource.Should().Be("main");
+            _root.Spans[1].Type.Should().Be("sql");
+            _root.Spans[1].Error.Should().Be(0);
+            _root.Spans[1].Meta["sql.CommandText"].Should().Be("SELECT COUNT(*) FROM Customers");
+            _root.Spans[1].Meta["sql.CommandType"].Should().Be("Text");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _conn.Close();
+        }
+    }
+}

--- a/src/DataDog.Tracing.Sql.Tests/EntityFrameworkCore/TraceDbConnectionTests.cs
+++ b/src/DataDog.Tracing.Sql.Tests/EntityFrameworkCore/TraceDbConnectionTests.cs
@@ -1,0 +1,41 @@
+﻿using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using NUnit.Framework;
+
+namespace DataDog.Tracing.Sql.Tests.EntityFrameworkCore
+{
+    [TestFixture]
+    public class TraceDbConnectionTests
+    {
+        RootSpan _root;
+        SqliteConnection _conn;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new RootSpan();
+            _conn = new SqliteConnection("Filename=./test.db");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _conn.Dispose();
+        }
+
+        [Test]
+        public void Open_should_be_traced()
+        {
+            var conn = new Sql.EntityFrameworkCore.TraceDbConnection(_conn, _root);
+            _root.Spans.Count.Should().Be(1);
+            conn.Open();
+            _root.Spans.Count.Should().Be(2);
+            var s = _root.Spans[1];
+            s.Error.Should().Be(0);
+            s.Name.Should().Be("sql.connect");
+            s.Service.Should().Be("sql");
+            s.Resource.Should().Be("main");
+            s.Type.Should().Be("sql");
+        }
+    }
+}

--- a/src/DataDog.Tracing.Sql/EntityFrameworkCore/TraceDbCommand.cs
+++ b/src/DataDog.Tracing.Sql/EntityFrameworkCore/TraceDbCommand.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Data;
+using System.Data.Common;
+
+namespace DataDog.Tracing.Sql.EntityFrameworkCore
+{
+    public class TraceDbCommand : DbCommand
+    {
+        private const string ServiceName = "sql";
+
+        private readonly DbCommand _command;
+        private readonly ISpanSource _spanSource;
+
+        public IDbCommand InnerCommand => _command;
+
+        protected override DbParameterCollection DbParameterCollection => _command.Parameters;
+
+        public override bool DesignTimeVisible
+        {
+            get => _command.DesignTimeVisible;
+            set => _command.DesignTimeVisible = value;
+        }
+
+        public override string CommandText
+        {
+            get => _command.CommandText;
+            set => _command.CommandText = value;
+        }
+
+        public override int CommandTimeout
+        {
+            get => _command.CommandTimeout;
+            set => _command.CommandTimeout = value;
+        }
+
+        public override CommandType CommandType
+        {
+            get => _command.CommandType;
+            set => _command.CommandType = value;
+        }
+
+        protected override DbConnection DbConnection
+        {
+            get => _command.Connection;
+            set => _command.Connection = value;
+        }
+
+        public override UpdateRowSource UpdatedRowSource
+        {
+            get => _command.UpdatedRowSource;
+            set => _command.UpdatedRowSource = value;
+        }
+
+        protected override DbTransaction DbTransaction
+        {
+            get => _command.Transaction;
+            set => _command.Transaction =
+                value is TraceDbTransaction transaction
+                    ? transaction.Transaction
+                    : value;
+        }
+
+        public TraceDbCommand(DbCommand command)
+            : this(command, TraceContextSpanSource.Instance) { }
+
+        public TraceDbCommand(DbCommand command, ISpanSource spanSource)
+        {
+            _command = command ?? throw new ArgumentNullException(nameof(command));
+            _spanSource = spanSource ?? throw new ArgumentNullException(nameof(spanSource));
+        }
+
+        public new void Dispose() => _command.Dispose();
+
+        public override void Cancel() => _command.Cancel();
+
+        public override void Prepare() => _command.Prepare();
+
+        protected override DbParameter CreateDbParameter() => _command.CreateParameter();
+
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+        {
+            const string name = "sql." + nameof(ExecuteReader);
+            var span = _spanSource.Begin(name, ServiceName, _command.Connection.Database, ServiceName);
+            try
+            {
+                if (span != null)
+                {
+                    const string metaKey = "sql." + nameof(CommandBehavior);
+                    span.SetMeta(metaKey, behavior.ToString("x"));
+                    SetMeta(span);
+                }
+
+                return _command.ExecuteReader(behavior);
+            }
+            catch (Exception ex)
+            {
+                span?.SetError(ex);
+                throw;
+            }
+            finally
+            {
+                span?.Dispose();
+            }
+        }
+
+        public override int ExecuteNonQuery()
+        {
+            const string name = "sql." + nameof(ExecuteNonQuery);
+            var span = _spanSource.Begin(name, ServiceName, _command.Connection.Database, ServiceName);
+            try
+            {
+                var result = _command.ExecuteNonQuery();
+                if (span != null)
+                {
+                    span.SetMeta("sql.RowsAffected", result.ToString());
+                    SetMeta(span);
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                span?.SetError(ex);
+                throw;
+            }
+            finally
+            {
+                span?.Dispose();
+            }
+        }
+
+        public override object ExecuteScalar()
+        {
+            const string name = "sql." + nameof(ExecuteScalar);
+            var span = _spanSource.Begin(name, ServiceName, _command.Connection.Database, ServiceName);
+            try
+            {
+                if (span != null)
+                    SetMeta(span);
+
+                return _command.ExecuteScalar();
+            }
+            catch (Exception ex)
+            {
+                span?.SetError(ex);
+                throw;
+            }
+            finally
+            {
+                span?.Dispose();
+            }
+        }
+
+        private void SetMeta(ISpan span)
+        {
+            span.SetMeta("sql.CommandText", CommandText);
+            span.SetMeta("sql.CommandType", CommandType.ToString());
+        }
+    }
+}

--- a/src/DataDog.Tracing.Sql/EntityFrameworkCore/TraceDbConnection.cs
+++ b/src/DataDog.Tracing.Sql/EntityFrameworkCore/TraceDbConnection.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Data;
+using System.Data.Common;
+
+namespace DataDog.Tracing.Sql.EntityFrameworkCore
+{
+    public class TraceDbConnection : DbConnection
+    {
+        private const string ServiceName = "sql";
+
+        private readonly ISpanSource _spanSource;
+        private readonly DbConnection _connection;
+
+        public IDbConnection InnerConnection => _connection;
+
+        public override int ConnectionTimeout => _connection.ConnectionTimeout;
+
+        public override string Database => _connection.Database;
+
+        public override string DataSource => _connection.DataSource;
+
+        public override string ServerVersion => _connection.ServerVersion;
+
+        public override ConnectionState State => _connection.State;
+
+        public override string ConnectionString
+        {
+            get => _connection.ConnectionString;
+            set => _connection.ConnectionString = value;
+        }
+
+        public TraceDbConnection(DbConnection connection)
+            : this(connection, TraceContextSpanSource.Instance) { }
+
+        public TraceDbConnection(DbConnection connection, ISpanSource spanSource)
+        {
+            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+            _spanSource = spanSource ?? throw new ArgumentNullException(nameof(spanSource));
+        }
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) =>
+            new TraceDbTransaction(this, _connection.BeginTransaction(isolationLevel));
+
+        protected override DbCommand CreateDbCommand()
+            => new TraceDbCommand(_connection.CreateCommand(), _spanSource);
+
+        public new void Dispose()
+            => _connection.Dispose();
+
+        public override void ChangeDatabase(string databaseName)
+            => _connection.ChangeDatabase(databaseName);
+
+        public override void Close()
+            => _connection.Close();
+
+        public override void Open()
+        {
+            var span = _spanSource.Begin("sql.connect", ServiceName, _connection.Database, ServiceName);
+            try
+            {
+                _connection.Open();
+            }
+            catch (Exception ex)
+            {
+                span?.SetError(ex);
+                throw;
+            }
+            finally
+            {
+                span?.Dispose();
+            }
+        }
+    }
+}

--- a/src/DataDog.Tracing.Sql/EntityFrameworkCore/TraceDbTransaction.cs
+++ b/src/DataDog.Tracing.Sql/EntityFrameworkCore/TraceDbTransaction.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Data;
+using System.Data.Common;
+
+namespace DataDog.Tracing.Sql.EntityFrameworkCore
+{
+    // Entity Framework has a check like this:
+    // if (connection.DbConnection != transaction.Connection)
+    //     throw new InvalidOperationException(RelationalStrings.TransactionAssociatedWithDifferentConnection);
+    // Where connection.DbConnection is of type TraceDbConnection and transaction.Connection is of type SqlConnection
+    // Because of this we need to implement TraceDbTransaction
+    public class TraceDbTransaction : DbTransaction
+    {
+        private const string ServiceName = "sql";
+
+        private readonly ISpanSource _spanSource;
+
+        protected override DbConnection DbConnection { get; }
+
+        public DbTransaction Transaction { get; }
+
+        public override IsolationLevel IsolationLevel => Transaction.IsolationLevel;
+
+        public TraceDbTransaction(DbConnection connection, DbTransaction transaction)
+            : this(connection, transaction, TraceContextSpanSource.Instance) { }
+
+        public TraceDbTransaction(DbConnection connection, DbTransaction transaction, ISpanSource spanSource)
+        {
+            DbConnection = connection ?? throw new ArgumentNullException(nameof(connection));
+            Transaction = transaction ?? throw new ArgumentNullException(nameof(transaction));
+            _spanSource = spanSource ?? throw new ArgumentNullException(nameof(spanSource));
+        }
+
+        public override void Commit()
+        {
+            const string name = "sql." + nameof(Commit);
+            var span = _spanSource.Begin(name, ServiceName, Transaction.Connection.Database, ServiceName);
+            try
+            {
+                Transaction.Commit();
+            }
+            catch (Exception ex)
+            {
+                span?.SetError(ex);
+                throw;
+            }
+            finally
+            {
+                span?.Dispose();
+            }
+        }
+
+        public override void Rollback()
+        {
+            const string name = "sql." + nameof(Rollback);
+            var span = _spanSource.Begin(name, ServiceName, Transaction.Connection.Database, ServiceName);
+            try
+            {
+                Transaction.Rollback();
+            }
+            catch (Exception ex)
+            {
+                span?.SetError(ex);
+                throw;
+            }
+            finally
+            {
+                span?.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Entity Framework is not able to deal with `IDbCommand` and `IDbConnection`, instead it wants the abstract class `DbConnection`, `DbCommand`. Internally it also does a reference compare between the connection and the connection of a transaction, because of this, we also wrap a `DbTransaction` in a `TraceDbTransaction`, as a nice side effect, it allows us to add spans for commit and rollback.